### PR TITLE
cobang: 1.4.3 -> 1.6.1

### DIFF
--- a/pkgs/by-name/co/cobang/package.nix
+++ b/pkgs/by-name/co/cobang/package.nix
@@ -18,14 +18,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cobang";
-  version = "1.4.3";
+  version = "1.6.1";
   pyproject = false; # Built with meson
 
   src = fetchFromGitHub {
     owner = "hongquan";
     repo = "CoBang";
     tag = "v${version}";
-    hash = "sha256-ggfFTK8XSr1UCBSpRE0992tnvJdKhAIVo6++v4neT7A=";
+    hash = "sha256-/0EfE4ZVfDFEbPel/g69sFqsBPMJ4pE9Fqz4t3o7jtY=";
   };
 
   # https://github.com/hongquan/CoBang/issues/117
@@ -63,6 +63,7 @@ python3Packages.buildPythonApplication rec {
     gst-python
     pillow
     pygobject3
+    gst-python
     python-zbar
   ];
 


### PR DESCRIPTION
Hey @Aleksanaa 

With the release of v1.6.0 the `cobang` has added detection which checks if the app is running in a sandbox, if it is, then `cobang` will request permission and if not, it will just access the camera directly (as I understand it), which have resolved the problems I had (on my `aarch64-linux`).
So if you merge these changes and can verify that it also works for you, when I will test on my `x86_64-linux` system when I get home from traveling, and hopefully, we can get the package updated 😁

https://github.com/hongquan/CoBang/issues/118#issuecomment-2798737463